### PR TITLE
Potential fix for code scanning alert no. 7: Reflected cross-site scripting

### DIFF
--- a/yuihub_api/src/context-builder.js
+++ b/yuihub_api/src/context-builder.js
@@ -4,6 +4,33 @@
 
 import { ContextPacketSchema } from './schemas/yuiflow.js';
 
+/**
+ * Escape markdown special characters to prevent injection attacks
+ * @param {string} str - String to escape
+ * @returns {string} Escaped string
+ */
+function escapeMarkdown(str) {
+  // Comprehensive escape: HTML entities + Markdown special characters
+  return String(str)
+    .replace(/&/g, '&amp;')        // Must be first to avoid double-escaping
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+    .replace(/`/g, '&#96;')         // Backticks (code blocks)
+    .replace(/\[/g, '&#91;')        // Square brackets (links)
+    .replace(/\]/g, '&#93;')
+    .replace(/\(/g, '&#40;')        // Parentheses (links)
+    .replace(/\)/g, '&#41;')
+    .replace(/\{/g, '&#123;')       // Curly braces
+    .replace(/\}/g, '&#125;')
+    .replace(/\*/g, '&#42;')        // Asterisks (bold/italic)
+    .replace(/_/g, '&#95;')         // Underscores (bold/italic)
+    .replace(/#/g, '&#35;')         // Hash (headers)
+    .replace(/\|/g, '&#124;')       // Pipe (tables)
+    .replace(/\\/g, '&#92;');       // Backslash (escape character)
+}
+
 export class ContextBuilder {
   constructor(storage, searchService) {
     this.storage = storage;
@@ -146,15 +173,6 @@ export class ContextBuilder {
       includeMetadata = true,
       includeKnots = true
     } = options;
-
-    function escapeMarkdown(str) {
-      // Minimal escape: replace <, >, &, and optionally backticks
-      return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/`/g, '&#96;');
-    }
 
     try {
       const packet = await this.buildPacket(thread, 'copilot-export', { includeKnots });

--- a/yuihub_api/src/context-builder.js
+++ b/yuihub_api/src/context-builder.js
@@ -147,10 +147,20 @@ export class ContextBuilder {
       includeKnots = true
     } = options;
 
+    function escapeMarkdown(str) {
+      // Minimal escape: replace <, >, &, and optionally backticks
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/`/g, '&#96;');
+    }
+
     try {
       const packet = await this.buildPacket(thread, 'copilot-export', { includeKnots });
       
-      let markdown = `# Thread: ${thread}\n\n`;
+      const escapedThread = escapeMarkdown(thread);
+      let markdown = `# Thread: ${escapedThread}\n\n`;
       
       if (includeMetadata) {
         markdown += `**Intent**: ${packet.intent}\n`;


### PR DESCRIPTION
Potential fix for [https://github.com/vemikrs/yuihub/security/code-scanning/7](https://github.com/vemikrs/yuihub/security/code-scanning/7)

To fix the problem, the user-provided `thread` parameter (from `req.params.thread`), which is interpolated directly into the markdown string in `ContextBuilder.generateCopilotMarkdown()`, needs to be sanitized or escaped before being returned to the client. The single best approach here is to contextually escape/encode the value injected into the markdown to ensure that any raw HTML or potentially executable content is neutralized. 
For Markdown, escaping can be accomplished by replacing any instances of `<` and `>` (which could allow HTML injection) with their respective entities, and also other characters as needed (like `&`, backticks, etc.). The most robust fix is to use a well-known external package for escaping markdown input, such as `markdown-escape` or a utility function, to ensure the Markdown cannot be interpreted as HTML by downstream renderers. If an external library is not available, inject a simple escape routine to replace dangerous characters.

Specifically:
- In `yuihub_api/src/context-builder.js`, update `generateCopilotMarkdown()` so the `thread` parameter used in the markdown string is properly escaped using a function like `escapeMarkdown`.
- Add an `escapeMarkdown` function to `context-builder.js`, either by importing an external library or by implementing a minimal escaping routine for `<`, `>`, and `&` (and optionally the backtick and other markdown-sensitive characters).
- If using an external library, import it at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
