### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/yuihub_api/src/server.js
+++ b/yuihub_api/src/server.js
@@ -346,6 +346,13 @@ app.get('/openapi.yml', async (req, reply) => {
 });
 
 // Privacy policy endpoint
+app.register(rateLimit, {
+  max: 5, // maximum 5 requests per minute per IP
+  timeWindow: '1 minute',
+  allowList: [], // set to array of trusted IPs if needed
+  keyGenerator: (req) => req.ip,
+  skipOnError: false
+});
 app.get('/privacy', async (req, reply) => {
   try {
     const fs = await import('fs/promises');


### PR DESCRIPTION
Potential fix for [https://github.com/vemikrs/yuihub/security/code-scanning/6](https://github.com/vemikrs/yuihub/security/code-scanning/6)

To fix this issue, we should protect the `/privacy` route with rate limiting middleware, using the available Fastify plugin (`@fastify/rate-limit`). The best solution is to apply this rate limiter specifically to the `/privacy` endpoint to limit how often a client can trigger the expensive file system operation. Fastify allows per-route plugin registration using its `app.register()` API in combination with route-level configuration. We will:

- Register the `@fastify/rate-limit` plugin on the `/privacy` route only.
- Configure appropriate defaults: e.g., `max: 5` requests per minute (can be tuned).
- Make the minimal code addition before the route definition.

No change of existing functionality is required, merely the addition of a rate limiter to that route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
