### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/yuihub_api/src/server.js
+++ b/yuihub_api/src/server.js
@@ -262,7 +262,14 @@ app.post('/ops/reindex', async (req, reply) => {
 });
 
 // OpenAPI schema endpoint for ChatGPT Actions
-app.get('/openapi.yml', async (req, reply) => {
+app.get('/openapi.yml', {
+  config: {
+    rateLimit: {
+      max: 10, // maximum 10 requests
+      timeWindow: '1 minute'
+    }
+  }
+}, async (req, reply) => {
   try {
     const fs = await import('fs/promises');
     const schemaPath = path.join(__dirname, '../openapi.yml');


### PR DESCRIPTION
Potential fix for [https://github.com/vemikrs/yuihub/security/code-scanning/5](https://github.com/vemikrs/yuihub/security/code-scanning/5)

To fix the issue, we should enable rate limiting for the `/openapi.yml` endpoint. Fastify's `@fastify/rate-limit` supports per-route configuration, so we can add a `{ config: { rateLimit: {/* options */} } }` object to the route definition. The optimal fix is to add a reasonable rate limit to this endpoint directly without altering its existing logic.

- Set up a sensible rate limit for this endpoint, e.g., 10 requests per minute per IP for `/openapi.yml`.
- Adjust the `.get()` call for `/openapi.yml` to include `config: { rateLimit: { ... } }`.
- No need to globally change logic or add new imports as the plugin is already imported.
- The code change should only affect the relevant route registration within `yuihub_api/src/server.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
