### PR TITLE
fix(ci): add retry mechanism and HF model cache for flaky tests

### DIFF
--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Rebuild native modules
         run: pnpm rebuild --recursive
 
+      # Cache HuggingFace models to avoid flaky downloads
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-${{ runner.os }}-xenova-bge-m3-v1
+          restore-keys: |
+            hf-models-${{ runner.os }}-
+
       # Ensure npm CLI is latest for Trusted Publishing support
       - name: Update npm CLI
         run: npm install -g npm@latest

--- a/.github/workflows/vitest-tests.yml
+++ b/.github/workflows/vitest-tests.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Rebuild native modules
         run: pnpm rebuild --recursive
 
+      # Cache HuggingFace models to avoid flaky downloads
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-${{ runner.os }}-xenova-bge-m3-v1
+          restore-keys: |
+            hf-models-${{ runner.os }}-
+
       - name: Build all packages
         run: pnpm build:all
 


### PR DESCRIPTION
- Add retry logic (max 3 attempts with exponential backoff) to LocalEmbeddingService.init()
- Add HuggingFace model caching in GitHub Actions workflows (vitest-tests.yml, v1-release.yml)
- Prevents flaky test failures caused by incomplete model downloads

Fixes #70
