### PR TITLE
fix(renovate): exclude claude workflow files from auto-updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
     "config:recommended"
   ],
   "minimumReleaseAge": "3 days",
+  "ignorePaths": [
+    ".github/workflows/claude-code-review.yml",
+    ".github/workflows/claude.yml"
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## 原因

`anthropics/claude-code-action@v1` は OIDC トークン交換時に、実行中のワークフローファイルの内容が **default branch (main) と完全一致すること**をセキュリティ検証する。

Renovate が `actions/checkout` を更新する PR #141 に `.github/workflows/claude-code-review.yml` と `.github/workflows/claude.yml` が含まれているため、PR ブランチ上のワークフローが main と異なり OIDC 検証が失敗する:

```
App token exchange failed: 401 Unauthorized - Workflow validation failed.
The workflow file must exist and have identical content to the version
on the repository's default branch.
```

## 修正

`renovate.json` の `ignorePaths` にこの2ファイルを追加し、Renovate が自動更新しないようにする。

これらのファイルのアクション更新は手動で行う（変更後は main に直接マージするか、マージ前に一時的に Code Review 無効化が必要）。

## 副次対応

PR #141 (`renovate/actions-checkout-6.x`) はこの2ファイルへの変更を含むため、マージするか、2ファイルを除いた状態でブランチを更新する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)