### PR TITLE
fix(renovate): disable auto-update for @vscode/vsce>minimatch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
     {
       "matchPackageNames": ["@types/vscode"],
       "groupName": "vscode engine and types"
+    },
+    {
+      "matchPackageNames": ["@vscode/vsce>minimatch"],
+      "enabled": false,
+      "description": "@vscode/vsce is not compatible with minimatch v10+ (default export is no longer a function). Keep this override pinned at 3.x manually."
     }
   ]
 }


### PR DESCRIPTION
## 原因

`@vscode/vsce` は minimatch の旧 API（デフォルトエクスポートを関数として使う）に依存している。

```js
// @vscode/vsce 内部
minimatch_1.default(file, pattern)  // v3.x では動く
```

minimatch v10 で API が変わりデフォルトエクスポートが関数でなくなったため、`npx @vscode/vsce package` が以下のエラーで失敗する:

```
(0 , minimatch_1.default) is not a function
```

Renovate PR #137 がこの override を `3.1.5 → 10.2.5` に更新しようとして CI が壊れた。

## 修正

`renovate.json` に `packageRule` を追加し、`@vscode/vsce>minimatch` override の自動更新を無効化する。

この override は `@vscode/vsce` が minimatch v10 の新 API に対応するまで手動で管理する。

## 副次対応

PR #137 はクローズしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)