### PR TITLE
fix(ci): restore pnpm/action-setup before setup-node in release workflow

### DIFF
--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -27,16 +27,18 @@ jobs:
           fetch-depth: 0
           ref: main  # Always checkout latest main, not trigger SHA
 
-      # setup-node must run BEFORE pnpm/action-setup so that pnpm uses the
-      # pinned Node.js binary. If pnpm is set up first it latches onto whatever
-      # node is on PATH at that moment (system default on ubuntu-latest).
+      # pnpm/action-setup must run BEFORE setup-node so that setup-node can
+      # find pnpm to configure the pnpm store cache (cache: "pnpm").
+      # tree-sitter's C++20 requirement is handled by the pnpm patch in
+      # patches/tree-sitter@0.25.0.patch, so node version latching is no
+      # longer an issue.
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: "24.14.1"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
-
-      - uses: pnpm/action-setup@v5
 
       # Install build tools for native modules (tree-sitter requires node-gyp)
       - name: Install build tools


### PR DESCRIPTION
## 原因

PR #142 で `setup-node` → `pnpm/action-setup` の順に変更したが、`setup-node` の `cache: "pnpm"` オプションは pnpm が**インストール済み**であることを前提とする（pnpm store のパスを取得するため）。pnpm がまだない状態で実行すると:

```
Unable to locate executable file: pnpm
```

## 修正

元の順序 `pnpm/action-setup` → `setup-node` に戻す。

PR #142 でこの順序を変えた理由（pnpm がシステムの Node.js に latching する問題）は、`patches/tree-sitter@0.25.0.patch` で C++20 コンパイル問題を根本解決したため、もはや不要。

## 経緯

```
pnpm/action-setup → setup-node  (元の順序)
  → pnpm がシステム Node を掴む → tree-sitter C++20 エラー  ← PR #142 で発覚

setup-node → pnpm/action-setup  (PR #142 の変更)
  → cache:"pnpm" が pnpm を見つけられない  ← 今回の失敗

pnpm patch で tree-sitter C++20 を修正済み (PR #142)
  → 元の順序に戻しても C++20 エラーは発生しない  ← 本 PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)