### PR TITLE
fix(ci): resolve node-gyp for tree-sitter install in release workflow

### DIFF
--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -40,11 +40,16 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
-      # Install build tools for native modules (tree-sitter requires node-gyp)
+      # Install build tools for native modules (tree-sitter requires node-gyp).
+      # node-gyp must be on PATH before `pnpm install` runs lifecycle scripts;
+      # pnpm/action-setup's bundled node-gyp is not resolvable here because
+      # setup-node (running after pnpm/action-setup for `cache: "pnpm"`) shadows
+      # pnpm's bin dir, so we install node-gyp globally to guarantee resolution.
       - name: Install build tools
         run: |
           sudo apt-get update
           sudo apt-get install -y python3 build-essential
+          npm install -g node-gyp
 
       - run: pnpm install
 

--- a/.github/workflows/vitest-tests.yml
+++ b/.github/workflows/vitest-tests.yml
@@ -24,20 +24,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      # setup-node must run BEFORE pnpm/action-setup (mirrors v1-release.yml order)
+      # Install sequence must mirror v1-release.yml so release-time install
+      # failures surface on PR. pnpm/action-setup runs BEFORE setup-node so
+      # setup-node can configure the pnpm store cache (cache: "pnpm").
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      # Install build tools for native modules (tree-sitter requires node-gyp)
+      # Keep in sync with v1-release.yml: install node-gyp globally so
+      # tree-sitter's install script can spawn it during pnpm install.
       - name: Install build tools
         run: |
           sudo apt-get update
           sudo apt-get install -y python3 build-essential
+          npm install -g node-gyp
 
       - name: Install dependencies (root + workspaces)
         run: pnpm install


### PR DESCRIPTION
## Summary
- Root cause fix: `pnpm install` in `v1-release.yml` fails at tree-sitter's install script with `Error: spawn node-gyp ENOENT`. Caused by setup-node (run after pnpm/action-setup so `cache: \"pnpm\"` works) not exposing pnpm's bundled node-gyp on PATH. Install `node-gyp` globally in the "Install build tools" step to guarantee resolution.
- Detection fix: `vitest-tests.yml` previously ordered setup-node before pnpm/action-setup (no `cache: \"pnpm\"`), which happens to resolve node-gyp differently and hid the bug on PR. Aligned the install sequence with `v1-release.yml` (pnpm/action-setup → setup-node with `cache: \"pnpm\"` → install node-gyp) so the same install-time failure surfaces on PR, not only on push-to-main.

## Context
- Failing release run: https://github.com/vemikrs/yuihub/actions/runs/24555255158
- Error: `tree-sitter install: Error: spawn node-gyp ENOENT`
- Dependabot PR #151 was merged because its `Vitest Tests CI` check passed despite the release path being broken — the environment difference between the two workflows masked the regression.

## Test plan
- [ ] `Vitest Tests CI` on this PR passes with the new install sequence (verifies node-gyp fix works)
- [ ] After merge, next `V1 Release` run on main completes the `Run pnpm install` step without ENOENT

🤖 Generated with [Claude Code](https://claude.com/claude-code)