### PR TITLE
fix(ci): release paths filter + skip Claude review on Dependabot

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs: GitHub scrubs repository secrets on Dependabot-
+    # triggered runs, so CLAUDE_CODE_OAUTH_TOKEN is empty and the action
+    # fails env validation. Renovate runs as a normal GitHub App and keeps
+    # secret access, so it is still reviewed.
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -8,6 +8,11 @@ on:
       - "apps/v1/**"
       - "apps/vscode-client/**"
       - "packages/core/**"
+      # Dependency resolution and build artifacts are also published, so
+      # workspace-wide lock/package/patch changes must trigger a release.
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - "patches/**"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Two CI workflow fixes bundled together, both addressing silent failures uncovered while investigating #154 (merged hono security fix that never shipped).

### 1. Expand v1-release.yml push paths
Add `pnpm-lock.yaml`, root `package.json`, and `patches/**` to the path filter.

- Before: dep-update PRs that only touched `pnpm-lock.yaml` (most Renovate/Dependabot runs) did not trigger release. Recent hono security fix (#154), undici (#153), hono-node-server (#155) were merged to main but never published.
- `patches/**` added because `patches/tree-sitter@0.25.0.patch` directly changes the native build output of a published dependency.

### 2. Skip Claude Code Review on Dependabot PRs
Add `if: github.actor != 'dependabot[bot]'` to the `claude-review` job.

- GitHub scrubs repository secrets on Dependabot-triggered workflow runs, so `secrets.CLAUDE_CODE_OAUTH_TOKEN` expands to empty string and the action exits with `Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required`.
- Currently causing false-red on all open Dependabot PRs (#157, #158, #159).
- Renovate is unaffected: it runs as a standard GitHub App and keeps secret access, so its PRs will still get Claude review.

## Trade-offs
- Release cadence increases: every dep-update PR will now trigger a release run. The existing `concurrency: v1-release` group serializes runs, and `Version Bump & Tag` auto-increments the suffix, so back-to-back runs are safe.
- Dependabot PRs lose automated Claude review. If this is undesired, the alternative is to register `CLAUDE_CODE_OAUTH_TOKEN` under repo Settings → Secrets → Dependabot secrets.

## Test plan
- [ ] This PR only touches `.github/workflows/**` (not in the new paths), so merging alone must NOT trigger a release — confirms the filter still excludes workflow-only changes.
- [ ] After merge, next Dependabot PR should show `claude-review` skipped (not failed).
- [ ] After merge, next dep-update merge with lockfile/package.json changes should trigger a v1 release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)