### PR TITLE
ci(diag): log git status before rebase in release workflow

### DIFF
--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -127,7 +127,20 @@ jobs:
         run: |
           git add VERSION package.json packages/core/package.json apps/v1/backend/package.json apps/v1/mcp-server/package.json apps/vscode-client/package.json
           git commit -m "chore(release): v${{ steps.version.outputs.version }} [skip ci]" || true
-          
+
+          # Diagnostic: rebase has been failing with "You have unstaged changes".
+          # Capture tracked-but-unstaged files so we can identify which build
+          # step is writing to a tracked path. Remove once fix is in place.
+          echo "::group::git status --porcelain (post-commit)"
+          git status --porcelain
+          echo "::endgroup::"
+          echo "::group::git diff --stat (unstaged tracked changes)"
+          git diff --stat
+          echo "::endgroup::"
+          echo "::group::git diff (first 200 lines)"
+          git diff | head -200
+          echo "::endgroup::"
+
           MAX_RETRIES=3
           for i in $(seq 1 $MAX_RETRIES); do
             git fetch origin main && git rebase origin/main && git push origin main && exit 0


### PR DESCRIPTION
## Purpose
Diagnostic-only PR. Adds \`git status --porcelain\` + \`git diff --stat\` + \`git diff\` (head -200) output immediately after the release commit, before the rebase loop in \`v1-release.yml\`.

## Why
The release workflow has been failing with:
\`\`\`
error: cannot rebase: You have unstaged changes.
\`\`\`
after a successful \`git commit\`. Current logs don't reveal *which* tracked files are unstaged. This logging is a one-shot diagnostic; a follow-up PR will remove it once the root cause is fixed.

## Plan
1. Merge this PR (workflow-only change — won't auto-trigger release via the paths filter).
2. Manually trigger \`V1 Release\` via \`workflow_dispatch\`.
3. Read the new log sections in the failing run, identify the dirty file(s).
4. Submit a follow-up PR that removes the diagnostics and fixes the root cause.

## Test plan
- [ ] PR CI passes (workflow-only change; no functional code touched).
- [ ] Post-merge manual \`workflow_dispatch\` run prints populated \`git status --porcelain\` output and still fails at rebase as before (expected; diagnostic does not fix the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)