### PR TITLE
fix(ci): stop pnpm from drifting lockfile during release

### DIFF
--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -56,7 +56,7 @@ jobs:
           sudo apt-get install -y python3 build-essential
           npm install -g node-gyp
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
 
       # Force rebuild native modules for this platform
       - name: Rebuild native modules
@@ -127,19 +127,6 @@ jobs:
         run: |
           git add VERSION package.json packages/core/package.json apps/v1/backend/package.json apps/v1/mcp-server/package.json apps/vscode-client/package.json
           git commit -m "chore(release): v${{ steps.version.outputs.version }} [skip ci]" || true
-
-          # Diagnostic: rebase has been failing with "You have unstaged changes".
-          # Capture tracked-but-unstaged files so we can identify which build
-          # step is writing to a tracked path. Remove once fix is in place.
-          echo "::group::git status --porcelain (post-commit)"
-          git status --porcelain
-          echo "::endgroup::"
-          echo "::group::git diff --stat (unstaged tracked changes)"
-          git diff --stat
-          echo "::endgroup::"
-          echo "::group::git diff (first 200 lines)"
-          git diff | head -200
-          echo "::endgroup::"
 
           MAX_RETRIES=3
           for i in $(seq 1 $MAX_RETRIES); do

--- a/.github/workflows/vitest-tests.yml
+++ b/.github/workflows/vitest-tests.yml
@@ -45,7 +45,7 @@ jobs:
           npm install -g node-gyp
 
       - name: Install dependencies (root + workspaces)
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Rebuild native modules
         run: pnpm rebuild --recursive

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Disable pnpm's auto-write of `packageManagerDependencies` into pnpm-lock.yaml.
+# With this on (default), pnpm rewrites the lockfile to record its own version
+# on every install, which caused the release workflow's `git rebase` to fail
+# with "unstaged changes" after the release commit. See PR #161 diagnostics.
+manage-package-manager-versions=false


### PR DESCRIPTION
## Root cause (from PR #161 diagnostics)
After the release commit, \`pnpm-lock.yaml\` was left with 94 unstaged insertions — a \`packageManagerDependencies\` section tracking pnpm itself:
\`\`\`yaml
  .:
    packageManagerDependencies:
      '@pnpm/exe':
        specifier: 10.33.0
      pnpm:
        specifier: 10.33.0
\`\`\`
This is pnpm 10's default \`manage-package-manager-versions=true\` behavior. The write happens **independently of \`--frozen-lockfile\`** (frozen-lockfile only covers the deps graph, not pnpm's self-tracking). That's why the release \`git rebase\` kept failing with \`You have unstaged changes\`.

## Fix
1. **\`.npmrc\`**: \`manage-package-manager-versions=false\` — disables the auto-write. pnpm is installed via \`pnpm/action-setup@v6\` already, so pnpm doesn't need to self-manage.
2. **\`--frozen-lockfile\`** on \`pnpm install\` in both \`v1-release.yml\` and \`vitest-tests.yml\` — defense in depth. Frozen is CI-default but explicit is clearer, and any future lockfile drift will surface loudly at install time.
3. **Remove diagnostic logging** added in PR #161.

## Test plan
- [ ] PR CI (Vitest) passes with \`--frozen-lockfile\` — confirms the current lockfile matches project package.jsons.
- [ ] Post-merge manual \`workflow_dispatch\` of V1 Release completes green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)