### PR TITLE
fix(ci): reset working tree before release rebase

### DIFF
--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -128,6 +128,16 @@ jobs:
           git add VERSION package.json packages/core/package.json apps/v1/backend/package.json apps/v1/mcp-server/package.json apps/vscode-client/package.json
           git commit -m "chore(release): v${{ steps.version.outputs.version }} [skip ci]" || true
 
+          # Build/test steps can leave tracked files dirty (e.g. pnpm rewriting
+          # pnpm-lock.yaml, rebuild updating patches/). Surface what was dirty
+          # for visibility, then reset so the following rebase can proceed.
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::warning::Unstaged changes after release commit — discarding before rebase:"
+            git status --porcelain
+            git diff --stat
+            git reset --hard HEAD
+          fi
+
           MAX_RETRIES=3
           for i in $(seq 1 $MAX_RETRIES); do
             git fetch origin main && git rebase origin/main && git push origin main && exit 0


### PR DESCRIPTION
## Why another PR
PR #162 (\`.npmrc manage-package-manager-versions=false\` + \`--frozen-lockfile\`) did not fully fix the release. Run 24572203055 still failed at \`Commit & Push to main\` with the same \`You have unstaged changes\` error — some other step is dirtying a tracked file, and I prematurely removed the diagnostic logging.

## Fix
Two changes in one block:
- **\`::warning::\` log + \`git status\` + \`git diff --stat\`** between commit and rebase — surfaces the current culprit in the Actions UI.
- **\`git reset --hard HEAD\`** — discards unstaged drift so rebase proceeds. Safe: the release commit is already made, and downstream steps (Build All, Package VSCode, publish) regenerate any derivatives they need.

This unblocks the release green path, and the warning log keeps the root-cause chase observable for follow-up.

## Test plan
- [ ] PR CI passes (workflow-only change).
- [ ] Post-merge \`workflow_dispatch\` V1 Release completes through Publish + GitHub Release green.
- [ ] \`::warning::\` line in logs names the dirty file so a follow-up PR can root-cause it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)