### PR TITLE
fix(ci): move managePackageManagerVersions to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-# Disable pnpm's auto-write of `packageManagerDependencies` into pnpm-lock.yaml.
-# With this on (default), pnpm rewrites the lockfile to record its own version
-# on every install, which caused the release workflow's `git rebase` to fail
-# with "unstaged changes" after the release commit. See PR #161 diagnostics.
-manage-package-manager-versions=false

--- a/package.json
+++ b/package.json
@@ -30,36 +30,5 @@
   },
   "dependencies": {
     "sharp": "0.34.5"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "sharp",
-      "tree-sitter",
-      "tree-sitter-javascript",
-      "tree-sitter-typescript"
-    ],
-    "peerDependencyRules": {
-      "ignoreMissing": [],
-      "allowedVersions": {
-        "tree-sitter-typescript>tree-sitter": "*",
-        "tree-sitter-javascript>tree-sitter": "*"
-      }
-    },
-    "overrides": {
-      "sharp": "0.34.5",
-      "@isaacs/brace-expansion": "5.0.1",
-      "markdown-it": "14.1.1",
-      "qs": "6.15.1",
-      "undici": "8.1.0",
-      "hono": "4.12.14",
-      "@hono/node-server": "1.19.14",
-      "express-rate-limit": "8.3.2",
-      "underscore": "1.13.8",
-      "minimatch": "10.2.5",
-      "@vscode/vsce>minimatch": "3.1.5"
-    },
-    "patchedDependencies": {
-      "tree-sitter@0.25.0": "patches/tree-sitter@0.25.0.patch"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,11 +3,40 @@ packages:
   - "apps/vscode-client"
   - "packages/*"
 
-# Prevent pnpm from writing a `packageManagerDependencies` section into
-# pnpm-lock.yaml on every install. pnpm is installed by pnpm/action-setup
-# in CI and by developers locally via the `packageManager` field + Corepack,
-# so we don't need pnpm to self-manage its own version.
-# Note: pnpm 10 reads this setting from pnpm-workspace.yaml only, NOT from
-# .npmrc — non-auth settings migrated in v10. An earlier .npmrc attempt
-# was silently ignored. See pnpm/pnpm discussion #9037.
+# pnpm 10 migrated non-auth settings out of .npmrc/package.json#pnpm into
+# pnpm-workspace.yaml. Keeping all pnpm settings in one file avoids
+# ERR_PNPM_LOCKFILE_CONFIG_MISMATCH caused by mixed source states.
+# See pnpm/pnpm discussion #9037.
+
+# Disable pnpm's auto-write of `packageManagerDependencies` into pnpm-lock.yaml.
+# pnpm is installed via pnpm/action-setup in CI and Corepack locally, so pnpm
+# does not need to self-manage its own version.
 managePackageManagerVersions: false
+
+onlyBuiltDependencies:
+  - sharp
+  - tree-sitter
+  - tree-sitter-javascript
+  - tree-sitter-typescript
+
+peerDependencyRules:
+  ignoreMissing: []
+  allowedVersions:
+    tree-sitter-typescript>tree-sitter: "*"
+    tree-sitter-javascript>tree-sitter: "*"
+
+overrides:
+  sharp: 0.34.5
+  "@isaacs/brace-expansion": 5.0.1
+  markdown-it: 14.1.1
+  qs: 6.15.1
+  undici: 8.1.0
+  hono: 4.12.14
+  "@hono/node-server": 1.19.14
+  express-rate-limit: 8.3.2
+  underscore: 1.13.8
+  minimatch: 10.2.5
+  "@vscode/vsce>minimatch": 3.1.5
+
+patchedDependencies:
+  tree-sitter@0.25.0: patches/tree-sitter@0.25.0.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,12 @@ packages:
   - "apps/v1/*"
   - "apps/vscode-client"
   - "packages/*"
+
+# Prevent pnpm from writing a `packageManagerDependencies` section into
+# pnpm-lock.yaml on every install. pnpm is installed by pnpm/action-setup
+# in CI and by developers locally via the `packageManager` field + Corepack,
+# so we don't need pnpm to self-manage its own version.
+# Note: pnpm 10 reads this setting from pnpm-workspace.yaml only, NOT from
+# .npmrc — non-auth settings migrated in v10. An earlier .npmrc attempt
+# was silently ignored. See pnpm/pnpm discussion #9037.
+managePackageManagerVersions: false


### PR DESCRIPTION
## Root cause (from web docs + local repro)
pnpm 10 migrated non-auth settings out of \`.npmrc\` and \`package.json#pnpm\` into \`pnpm-workspace.yaml\`. The PR started as a one-liner moving \`manage-package-manager-versions\` to the right file, but the initial push hit a second issue on CI:

\`\`\`
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
The current "overrides" configuration doesn't match the value found in the lockfile
\`\`\`

Leaving \`overrides\` / \`peerDependencyRules\` / \`onlyBuiltDependencies\` / \`patchedDependencies\` in \`package.json#pnpm\` while putting \`managePackageManagerVersions\` in \`pnpm-workspace.yaml\` put pnpm 10 in a mixed state that flunked the frozen-lockfile config check.

## Fix
1. Delete \`.npmrc\` (non-auth settings no longer read from there in pnpm 10).
2. Move **all** pnpm settings from \`package.json#pnpm\` into \`pnpm-workspace.yaml\`:
   - \`managePackageManagerVersions: false\` — the original trigger
   - \`onlyBuiltDependencies\`
   - \`peerDependencyRules\`
   - \`overrides\`
   - \`patchedDependencies\`
3. Safety-net block in \`v1-release.yml\` (from PR #163) retained as belt-and-suspenders.

## Local verification (pnpm 10.33.0)
\`\`\`
$ rm -rf node_modules && corepack pnpm install --frozen-lockfile
... Done in 1.9s using pnpm v10.33.0
$ git status --porcelain pnpm-lock.yaml
(clean — no drift)
\`\`\`

## Refs
- [pnpm Settings docs](https://pnpm.io/settings)
- [pnpm/pnpm discussion #9037 — settings migration to pnpm-workspace.yaml](https://github.com/orgs/pnpm/discussions/9037)

## Test plan
- [ ] PR CI: Vitest \`pnpm install --frozen-lockfile\` succeeds (proves lockfile is consistent with workspace config).
- [ ] Post-merge manual \`workflow_dispatch\` V1 Release completes green, and safety-net \`::warning::\` does **not** fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)