### PR TITLE
fix(ci): commit packageManagerDependencies into lockfile; revert workarounds

### DIFF
--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -128,16 +128,6 @@ jobs:
           git add VERSION package.json packages/core/package.json apps/v1/backend/package.json apps/v1/mcp-server/package.json apps/vscode-client/package.json
           git commit -m "chore(release): v${{ steps.version.outputs.version }} [skip ci]" || true
 
-          # Build/test steps can leave tracked files dirty (e.g. pnpm rewriting
-          # pnpm-lock.yaml, rebuild updating patches/). Surface what was dirty
-          # for visibility, then reset so the following rebase can proceed.
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::warning::Unstaged changes after release commit — discarding before rebase:"
-            git status --porcelain
-            git diff --stat
-            git reset --hard HEAD
-          fi
-
           MAX_RETRIES=3
           for i in $(seq 1 $MAX_RETRIES); do
             git fetch origin main && git rebase origin/main && git push origin main && exit 0

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-# Disable pnpm's auto-write of `packageManagerDependencies` into pnpm-lock.yaml.
-# With this on (default), pnpm rewrites the lockfile to record its own version
-# on every install, which caused the release workflow's `git rebase` to fail
-# with "unstaged changes" after the release commit. See PR #161 diagnostics.
-manage-package-manager-versions=false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,97 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 10.33.0
+        version: 10.33.0
+      pnpm:
+        specifier: 10.33.0
+        version: 10.33.0
+
+packages:
+
+  '@pnpm/exe@10.33.0':
+    resolution: {integrity: sha512-sGsjztJBelzVMd0RhceDJ3p8Hk7eBcpu4G/TF6REzIvNdkKyxDT0czc1BWyo8Kbg+U0OBtK/TAGXN7Art4rTdg==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@10.33.0':
+    resolution: {integrity: sha512-oYb5NxEyImqaTkLVX/7jL59m9Vfmd07iLWzr4Pg2LIk4XEtAllNcnksNHcp5Uf+lFk/BggtpOdvC84TG3VnbFw==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/linux-x64@10.33.0':
+    resolution: {integrity: sha512-JYD2GXDF2roKpvTg5s032lYcUcT9lMedYlzxoqitWTjKlkMhl2gXRYpiDHdi2mWC5nFOJYlgYbUuy6jh3rXhng==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/macos-arm64@10.33.0':
+    resolution: {integrity: sha512-3w9Pqpw0swnAbnEdAKumMuKj+TPaGratnqC49bC41vjR1pNs0UMwVdOxiIROUMQy5OHKPx0IH/wOOP0hkhJd+g==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/macos-x64@10.33.0':
+    resolution: {integrity: sha512-SBeiLjU/9ORMIXAMsD6+Ltaaesniwh49FeFcG6kA64Zxr30U9SyzeZDnNOyWCGFjHeCmGfzCnSpNEN4VNo827g==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/win-arm64@10.33.0':
+    resolution: {integrity: sha512-8X3NQqmfNVZ+dCu+EfD7ZkAgDgIKKdAgBBKcvhvMoMJq/nWHOfqDLxewE9TQ7qzVLuUKG/9b/xBVRVjdtDOm0w==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@pnpm/win-x64@10.33.0':
+    resolution: {integrity: sha512-wiPVvxmTuB6FFn+rZ4FfSk1WTn+cxiQ7MTJEEz1k9VZLN/yZujGrv/WLYH2JcwzVTgObfmQuBKeNgEUavEL0Qg==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  pnpm@10.33.0:
+    resolution: {integrity: sha512-EFaLtKavtYyes2MNqQzJUWQXq+vT+rvmc58K55VyjaFJHp21pUTHatjrdXD1xLs9bGN7LLQb/c20f6gjyGSTGQ==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@10.33.0':
+    optionalDependencies:
+      '@pnpm/linux-arm64': 10.33.0
+      '@pnpm/linux-x64': 10.33.0
+      '@pnpm/macos-arm64': 10.33.0
+      '@pnpm/macos-x64': 10.33.0
+      '@pnpm/win-arm64': 10.33.0
+      '@pnpm/win-x64': 10.33.0
+
+  '@pnpm/linux-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/linux-x64@10.33.0':
+    optional: true
+
+  '@pnpm/macos-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/macos-x64@10.33.0':
+    optional: true
+
+  '@pnpm/win-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/win-x64@10.33.0':
+    optional: true
+
+  pnpm@10.33.0: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## TL;DR
Root-cause fix for the recurring "You have unstaged changes" rebase failure in V1 Release. Aligns with upstream pnpm practice and reverts the two earlier workaround PRs (#162 .npmrc, #163 safety-net).

## Path we walked (to save future debuggers' time)

| PR | Approach | Outcome |
|----|----------|---------|
| #162 | `.npmrc` with `manage-package-manager-versions=false` | pnpm 10 silently ignores non-auth settings in `.npmrc` on CI; drift persisted |
| #163 | safety-net: `git reset --hard HEAD` before rebase | worked mechanically, but *fights* pnpm instead of aligning with it; drift would reappear every release |
| #164 | move all pnpm settings to `pnpm-workspace.yaml` | triggered upstream bug [pnpm/pnpm#10614](https://github.com/pnpm/pnpm/issues/10614) (overrides disappear from lockfile) → `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, then `ERR_PNPM_IGNORED_BUILDS` — **closed superseded** |
| #165 (this) | commit the drift into lockfile as upstream does | root-cause fix |

## Upstream evidence

Inspected `github.com/pnpm/pnpm/pnpm-lock.yaml` directly: pnpm's own repository has a `packageManagerDependencies` YAML document committed at the top of its lockfile:
```yaml
---
lockfileVersion: '9.0'
importers:
  .:
    configDependencies: {}
    packageManagerDependencies:
      '@pnpm/exe': ...
      pnpm: ...
...
---
lockfileVersion: '9.0'
(rest of deps)
```
So the "correct" behavior is **the section exists in the lockfile**, not "suppress it". Our lockfile had been generated without it (macOS + corepack doesn't emit it), and every CI run was trying to add it.

Related OPEN upstream issues we also verified:
- [#10614](https://github.com/pnpm/pnpm/issues/10614) — overrides vanish from lockfile when moved to `pnpm-workspace.yaml`
- [#10258](https://github.com/pnpm/pnpm/issues/10258) — `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` with no diff (10.24+)
- [#10571](https://github.com/pnpm/pnpm/issues/10571) — lockfile change between 10.28.2 and 10.29.1 (reverted upstream in 595cd41)

## What this PR does

1. **Prepends the 94-line `packageManagerDependencies` YAML document** to `pnpm-lock.yaml`. Content extracted verbatim from the failing release run 24566516916 (PR #161's diagnostic log).
2. **Reverts PR #163's safety-net** (`git reset --hard HEAD` + warning log) in `v1-release.yml`. No longer needed.
3. **Deletes `.npmrc`** (PR #162's ineffective setting).

## Local verification (pnpm 10.33.0, macOS)
```
$ rm -rf node_modules && corepack pnpm install --frozen-lockfile
... Done in 1.7s using pnpm v10.33.0
$ git status pnpm-lock.yaml
(clean — no drift)
```

## Test plan
- [ ] PR CI passes — Vitest `pnpm install --frozen-lockfile` runs against the updated lockfile without errors.
- [ ] Post-merge manual `workflow_dispatch` of V1 Release completes green **and** the `Commit & Push to main` step shows **no lockfile drift** (confirming the root-cause fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)