### PR TITLE
chore(ci): add job timeout-minutes & bump Playwright

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,6 +17,7 @@ jobs:
   smoke-tests:
     name: Run Smoke Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
GitHub Actions の job ハング時に最大6時間課金される事故防止と、Playwright のブラウザDLハング既知バグ対策をまとめて行います。

- `timeout-minutes` 未設定の job に `timeout-minutes: 10` を付与（設定済みは変更なし）
- `@playwright/test` / `playwright` が 1.60.0 未満なら `^1.60.0` へ引き上げ（[microsoft/playwright#40747](https://github.com/microsoft/playwright/pull/40747) で修正済みの Node 24.16+ ハング対策）
- 対象 lockfile を更新

自動生成PR。マージは手動。
